### PR TITLE
Overhauls to allow importing multiple parser modules w/o causing class overloading corruptions

### DIFF
--- a/parsers/common.py
+++ b/parsers/common.py
@@ -30,9 +30,8 @@ class ParameterNames(object):
     when called by the individual parsers.
     '''
     # Initialize Parameter names with time as the only default parameter
-    parameters = [
-        'time'
-    ]
+    def __init__(self, parameters=[]):
+        self.parameters = ['time'] + parameters
 
     # Create the initial dictionary object.
     def create_dict(self):
@@ -42,13 +41,13 @@ class ParameterNames(object):
         '''
         bunch = Bunch()
 
-        for name in ParameterNames.parameters:
+        for name in self.parameters:
             bunch[name] = []
 
         return bunch
 
 
-class Parser(object):
+class ParserCommon(object):
     """
     A Parser class that begins the process of extracting data records from the
     DCL log files.
@@ -57,12 +56,12 @@ class Parser(object):
     using either readlines (if the file is ascii), or read if the file is a
     pure binary file.
     """
-    def __init__(self, infile):
+    def initialize(self, infile, parameters):
         # set the infile name and path
         self.infile = infile
 
         # initialize the data dictionary using the names defined above
-        data = ParameterNames()
+        data = ParameterNames(parameters)
         self.data = data.create_dict()
         self.raw = None
 

--- a/parsers/parse_adcp.py
+++ b/parsers/parse_adcp.py
@@ -25,7 +25,7 @@ from bunch import Bunch
 from struct import unpack
 
 # Import common utilites and base classes
-from common import Parser
+from common import ParserCommon
 from common import dcl_to_epoch, inputs, DCL_TIMESTAMP, NEWLINE
 
 # Regex set to find the start of a PD0 packet (DCL timestamp and the first 6 
@@ -234,7 +234,7 @@ class ParameterNames(object):
         return bunch
 
 
-class Parser(Parser):
+class Parser(ParserCommon):
     """
     A Parser class that extracts the data records from a PD0 data packet 
     formatted in ASCIIHEX produced by a Teledyne RDI Workhorse ADCP.
@@ -648,7 +648,7 @@ if __name__ == '__main__':
     outfile = os.path.abspath(args.outfile)
 
     # initialize the Parser object for PWRSYS
-    adcp = Parser(infile)
+    adcp = ParserCommon(infile)
 
     # load the data into a buffered object and parse the data into a dictionary
     adcp.load_ascii()

--- a/parsers/parse_ctdbp.py
+++ b/parsers/parse_ctdbp.py
@@ -13,7 +13,7 @@ import re
 import scipy.io as sio
 
 # Import common utilites and base classes
-from common import ParameterNames, Parser
+from common import ParameterNames, ParserCommon
 from common import dcl_to_epoch, inputs, DCL_TIMESTAMP, FLOAT, INTEGER, NEWLINE
 
 # Set regex strings to just find the CTD data (with options for DOSTA or FLORT).
@@ -67,7 +67,7 @@ class ParameterNames(ParameterNames):
             ])
 
 
-class Parser(Parser):
+class Parser(ParserCommon):
     """
     A Parser subclass that calls the Parser base class, adds the CTDBP specific
     methods to parse the data, and extracts the CTDBP data records from the DCL
@@ -140,7 +140,7 @@ if __name__ == '__main__':
     ctd_type = args.switch
 
     # initialize the Parser object for CTDBP
-    ctdbp = Parser(infile, ctd_type)
+    ctdbp = ParserCommon(infile, ctd_type)
 
     # load the data into a buffered object and parse the data into a dictionary
     ctdbp.load_ascii()

--- a/parsers/parse_ctdbp.py
+++ b/parsers/parse_ctdbp.py
@@ -23,7 +23,7 @@ CTD_DATE = r'(\d{2}\s\w{3}\s\d{4}\s\d{2}:\d{2}:\d{2})'
 
 BASE_PATTERN = (
     DCL_TIMESTAMP + r'\s+' +    # DCL Time-Stamp
-    r'(?:\[\w*:\w*\]:\s*)*' +   # DCL logger ID (may not be present)
+    r'(?:\[\w*:\w*\]:|\#)*\s+' +   # DCL logger ID (may not be present)
     FLOAT + r',\s+' +           # temperature
     FLOAT + r',\s+' +           # conductivity
     FLOAT + r',\s+'             # pressure

--- a/parsers/parse_ctdbp.py
+++ b/parsers/parse_ctdbp.py
@@ -13,7 +13,7 @@ import re
 import scipy.io as sio
 
 # Import common utilites and base classes
-from common import ParameterNames, ParserCommon
+from common import ParserCommon
 from common import dcl_to_epoch, inputs, DCL_TIMESTAMP, FLOAT, INTEGER, NEWLINE
 
 # Set regex strings to just find the CTD data (with options for DOSTA or FLORT).
@@ -34,37 +34,34 @@ CTDBP2 = BASE_PATTERN + DOSTA + CTD_DATE + NEWLINE
 CTDBP3 = BASE_PATTERN + FLORT + CTD_DATE + NEWLINE
 
 
-class ParameterNames(ParameterNames):
-    '''
-    Extend the parameter names with parameters for the CTDBP (time is already
-    declared in the base class).
-    '''
-    def __init__(self, ctd_type):
-        ParameterNames.parameters.extend([
-            'dcl_date_time_string',
-            'temperature',
-            'conductivity',
-            'pressure'
+def _get_parameter_names_ctdbp(ctd_type):
+    parameter_names = [
+        'dcl_date_time_string',
+        'temperature',
+        'conductivity',
+        'pressure'
+        ]
+
+    if ctd_type == 1:
+        parameter_names.extend([
+            'ctd_date_time_string'
         ])
 
-        if ctd_type == 1:
-            ParameterNames.parameters.extend([
-                'ctd_date_time_string'
-            ])
+    if ctd_type == 2:
+        parameter_names.extend([
+            'oxygen_concentration',
+            'ctd_date_time_string'
+        ])
 
-        if ctd_type == 2:
-            ParameterNames.parameters.extend([
-                'oxygen_concentration',
-                'ctd_date_time_string'
-            ])
+    if ctd_type == 3:
+        parameter_names.extend([
+            'raw_backscatter',
+            'raw_chlorophyll',
+            'raw_cdom',
+            'ctd_date_time_string'
+        ])
 
-        if ctd_type == 3:
-            ParameterNames.parameters.extend([
-                'raw_backscatter',
-                'raw_chlorophyll',
-                'raw_cdom',
-                'ctd_date_time_string'
-            ])
+    return parameter_names
 
 
 class Parser(ParserCommon):
@@ -74,35 +71,30 @@ class Parser(ParserCommon):
     daily log files.
     """
     def __init__(self, infile, ctd_type):
-        # set the infile name and path
-        self.infile = infile
+        self.initialize(infile, _get_parameter_names_ctdbp(ctd_type))
         self.ctd_type = ctd_type
 
-        # initialize the data dictionary using the names defined above
-        data = ParameterNames(ctd_type)
-        self.data = data.create_dict()
-
-    def parse_data(self, ctd_type):
+    def parse_data(self):
         '''
         Iterate through the record lines (defined via the regex expression
         above) in the data object, and parse the data into a pre-defined
         dictionary object created using the Bunch class.
         '''
-        if ctd_type == 1:
+        if self.ctd_type == 1:
             REGEX = re.compile(CTDBP1, re.DOTALL)
 
-        if ctd_type == 2:
+        if self.ctd_type == 2:
             REGEX = re.compile(CTDBP2, re.DOTALL)
 
-        if ctd_type == 3:
+        if self.ctd_type == 3:
             REGEX = re.compile(CTDBP3, re.DOTALL)
 
         for line in self.raw:
             match = REGEX.match(line)
             if match:
-                self._build_parsed_values(match, ctd_type)
+                self._build_parsed_values(match)
 
-    def _build_parsed_values(self, match, ctd_type):
+    def _build_parsed_values(self, match):
         """
         Extract the data from the relevant regex groups and assign to elements
         of the data dictionary.
@@ -118,14 +110,14 @@ class Parser(ParserCommon):
         self.data.conductivity.append(float(match.group(3)))
         self.data.pressure.append(float(match.group(4)))
 
-        if ctd_type == 1:
+        if self.ctd_type == 1:
             self.data.ctd_date_time_string.append(match.group(5))
 
-        if ctd_type == 2:
+        if self.ctd_type == 2:
             self.data.oxygen_concentration.append(match.group(5))
             self.data.ctd_date_time_string.append(match.group(6))
 
-        if ctd_type == 3:
+        if self.ctd_type == 3:
             self.data.raw_backscatter.append(match.group(5))
             self.data.raw_chlorophyll.append(match.group(6))
             self.data.raw_cdom.append(match.group(7))

--- a/parsers/parse_hydrogen.py
+++ b/parsers/parse_hydrogen.py
@@ -13,7 +13,7 @@ import re
 import scipy.io as sio
 
 # Import common utilites and base classes
-from common import ParameterNames, Parser
+from common import ParameterNames, ParserCommon
 from common import dcl_to_epoch, inputs, DCL_TIMESTAMP, FLOAT, NEWLINE
 
 
@@ -38,7 +38,7 @@ class ParameterNames(ParameterNames):
     ])
 
 
-class Parser(Parser):
+class Parser(ParserCommon):
     """
     A Parser subclass that calls the Parser base class, adds the METBK specific
     methods to parse the data, and extracts the METBK data records from the DCL
@@ -77,7 +77,7 @@ if __name__ == '__main__':
     outfile = os.path.abspath(args.outfile)
 
     # initialize the Parser object for hydrogen
-    hydrogen = Parser(infile)
+    hydrogen = ParserCommon(infile)
 
     # load the data into a buffered object and parse the data into a dictionary
     hydrogen.load_ascii()

--- a/parsers/parse_metbk.py
+++ b/parsers/parse_metbk.py
@@ -13,7 +13,7 @@ import re
 import scipy.io as sio
 
 # Import common utilites and base classes
-from common import ParameterNames, Parser
+from common import ParameterNames, ParserCommon
 from common import dcl_to_epoch, inputs, DCL_TIMESTAMP, FLOAT, NEWLINE
 
 
@@ -38,32 +38,30 @@ PATTERN = (
 REGEX = re.compile(PATTERN, re.DOTALL)
 
 
-class ParameterNames(ParameterNames):
-    '''
-    Extend the parameter names with parameters for the METBK (time is already
-    declared in the base class).
-    '''
-    ParameterNames.parameters.extend([
-        'dcl_date_time_string',
-        'barometric_pressure',
-        'relative_humidity',
-        'air_temperature',
-        'longwave_irradiance',
-        'precipitation_level',
-        'sea_surface_temperature',
-        'sea_surface_conductivity',
-        'shortwave_irradiance',
-        'eastward_wind_velocity',
-        'northward_wind_velocity'
-    ])
+_parameter_names_metbk = [
+    'dcl_date_time_string',
+    'barometric_pressure',
+    'relative_humidity',
+    'air_temperature',
+    'longwave_irradiance',
+    'precipitation_level',
+    'sea_surface_temperature',
+    'sea_surface_conductivity',
+    'shortwave_irradiance',
+    'eastward_wind_velocity',
+    'northward_wind_velocity'
+]
 
 
-class Parser(Parser):
+class Parser(ParserCommon):
     """
     A Parser subclass that calls the Parser base class, adds the METBK specific
     methods to parse the data, and extracts the METBK data records from the DCL
     daily log files.
     """
+    def __init__(self, infile):
+        self.initialize(infile, _parameter_names_metbk)
+
     def parse_data(self):
         '''
         Iterate through the record lines (defined via the regex expression

--- a/parsers/parse_metbk.py
+++ b/parsers/parse_metbk.py
@@ -13,7 +13,7 @@ import re
 import scipy.io as sio
 
 # Import common utilites and base classes
-from common import ParameterNames, ParserCommon
+from common import ParserCommon
 from common import dcl_to_epoch, inputs, DCL_TIMESTAMP, FLOAT, NEWLINE
 
 

--- a/parsers/parse_pwrsys.py
+++ b/parsers/parse_pwrsys.py
@@ -13,7 +13,7 @@ import re
 import scipy.io as sio
 
 # Import common utilites and base classes
-from common import ParameterNames, Parser
+from common import ParameterNames, ParserCommon
 from common import dcl_to_epoch, inputs, DCL_TIMESTAMP, FLOAT, NEWLINE
 
 # Regex pattern for the power system records
@@ -112,7 +112,7 @@ class ParameterNames(ParameterNames):
     ])
 
 
-class Parser(Parser):
+class Parser(ParserCommon):
     """
     A Parser subclass that calls the Parser base class, adds the PWRSYS specific
     methods to parse the data, and extracts the PWRSYS data records from the DCL
@@ -207,7 +207,7 @@ if __name__ == '__main__':
     outfile = os.path.abspath(args.outfile)
 
     # initialize the Parser object for PWRSYS
-    pwrsys = Parser(infile)
+    pwrsys = ParserCommon(infile)
 
     # load the data into a buffered object and parse the data into a dictionary
     pwrsys.load_ascii()

--- a/parsers/parse_superv_cpm.py
+++ b/parsers/parse_superv_cpm.py
@@ -13,7 +13,7 @@ import re
 import scipy.io as sio
 
 # Import common utilites and base classes
-from common import ParameterNames, Parser
+from common import ParameterNames, ParserCommon
 from common import dcl_to_epoch, inputs, DCL_TIMESTAMP, FLOAT, INTEGER, NEWLINE
 
 
@@ -91,7 +91,7 @@ class ParameterNames(ParameterNames):
     ])
 
 
-class Parser(Parser):
+class Parser(ParserCommon):
     """
     A Parser subclass that calls the Parser base class, adds the METBK specific
     methods to parse the data, and extracts the METBK data records from the DCL
@@ -184,7 +184,7 @@ if __name__ == '__main__':
     outfile = os.path.abspath(args.outfile)
 
     # initialize the Parser object for METBK
-    superv = Parser(infile)
+    superv = ParserCommon(infile)
 
     # load the data into a buffered object and parse the data into a dictionary
     superv.load_ascii()

--- a/parsers/parse_superv_dcl.py
+++ b/parsers/parse_superv_dcl.py
@@ -13,7 +13,7 @@ import re
 import scipy.io as sio
 
 # Import common utilites and base classes
-from common import ParameterNames, Parser
+from common import ParameterNames, ParserCommon
 from common import dcl_to_epoch, inputs, DCL_TIMESTAMP, FLOAT, INTEGER, NEWLINE
 
 
@@ -119,7 +119,7 @@ class ParameterNames(ParameterNames):
     ])
 
 
-class Parser(Parser):
+class Parser(ParserCommon):
     """
     A Parser subclass that calls the Parser base class, adds the METBK specific
     methods to parse the data, and extracts the METBK data records from the DCL
@@ -236,7 +236,7 @@ if __name__ == '__main__':
     outfile = os.path.abspath(args.outfile)
 
     # initialize the Parser object for METBK
-    superv = Parser(infile)
+    superv = ParserCommon(infile)
 
     # load the data into a buffered object and parse the data into a dictionary
     superv.load_ascii()

--- a/parsers/parse_wavss.py
+++ b/parsers/parse_wavss.py
@@ -13,7 +13,7 @@ import re
 import scipy.io as sio
 
 # Import common utilites and base classes
-from common import ParameterNames, Parser
+from common import ParameterNames, ParserCommon
 from common import dcl_to_epoch, inputs, DCL_TIMESTAMP, INTEGER, FLOAT, NEWLINE
 
 # Regex pattern for a line with a DCL time stamp, possible DCL status value and
@@ -42,39 +42,37 @@ PATTERN = (
 REGEX = re.compile(PATTERN, re.DOTALL)
 
 
-class ParameterNames(ParameterNames):
-    '''
-    Extend the parameter names with parameters for the wavss (time is already
-    declared in the base class).
-    '''
-    ParameterNames.parameters.extend([
-        'dcl_date_time_string',
-        'date_string',
-        'time_string',
-        'serial_number',
-        'num_zero_crossings',
-        'average_wave_height',
-        'mean_spectral_period',
-        'maximum_wave_height',
-        'significant_wave_height',
-        'significant_wave_period',
-        'average_tenth_height',
-        'average_tenth_period',
-        'average_wave_period',
-        'peak_period',
-        'peak_period_read',
-        'spectral_wave_height',
-        'mean_wave_direction',
-        'mean_directional_spread'
-    ])
+_parameter_names_wavss = [
+    'dcl_date_time_string',
+    'date_string',
+    'time_string',
+    'serial_number',
+    'num_zero_crossings',
+    'average_wave_height',
+    'mean_spectral_period',
+    'maximum_wave_height',
+    'significant_wave_height',
+    'significant_wave_period',
+    'average_tenth_height',
+    'average_tenth_period',
+    'average_wave_period',
+    'peak_period',
+    'peak_period_read',
+    'spectral_wave_height',
+    'mean_wave_direction',
+    'mean_directional_spread'
+]
 
 
-class Parser(Parser):
+class Parser(ParserCommon):
     """
     A Parser subclass that calls the Parser base class, adds the wavss specific
     methods to parse the data, and extracts the wavss data records from the DCL
     daily log files.
     """
+    def __init__(self, infile):
+        self.initialize(infile, _parameter_names_wavss)
+
     def parse_data(self):
         '''
         Iterate through the record lines (defined via the regex expression

--- a/parsers/parse_wavss.py
+++ b/parsers/parse_wavss.py
@@ -13,7 +13,7 @@ import re
 import scipy.io as sio
 
 # Import common utilites and base classes
-from common import ParameterNames, ParserCommon
+from common import ParserCommon
 from common import dcl_to_epoch, inputs, DCL_TIMESTAMP, INTEGER, FLOAT, NEWLINE
 
 # Regex pattern for a line with a DCL time stamp, possible DCL status value and


### PR DESCRIPTION
I tried to minimize the impact of these changes on the use of each parser in the conventional single-parser case, specially when run from the shell.

In `common.py`:
- renamed `Parser` class to `ParserCommon`, to avoid class name reuse in each parser
- changed `Parser` initialization approach
- added `ParameterNames` initialization method, which takes an optional parameters list

In parser modules:
- No longer declaring an overloaded instance of the `ParameterNames` class. A local list or function is used instead.
- Implemented a more consistent (across parsers) use of an initializations approach for the `Parser` class
- Implemented regex bug fix for `ctdbp`, from @cwingard 

I deliberately modified only the parsers I've tested and used: `parse_ctdbp.py`, `parse_metbk.py` and `parse_wavss.py`. The other parser modules got modified "automatically" through carelessness on my part when refactoring code with an IDE (PyCharm). I haven't tested those changes at all.