### PR TITLE
Use munch instead of bunch

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The following additional python packages are used by this code:
    * numpy >= 1.9.2
    * scipy >= 0.15.1
    * matplotlib >= 1.4.3
-   * bunch >= 1.0.1 (installed via pip)
+   * munch >= 2.0.4 
    * argparse >= 1.3.0
 
 # Contributing

--- a/cgsn_parsers/parsers/common.py
+++ b/cgsn_parsers/parsers/common.py
@@ -10,7 +10,7 @@ import argparse
 import datetime
 import re
 
-from bunch import Bunch
+from munch import Munch as Bunch
 from calendar import timegm
 from pytz import timezone
 

--- a/cgsn_parsers/parsers/parse_adcp.py
+++ b/cgsn_parsers/parsers/parse_adcp.py
@@ -18,7 +18,7 @@ import os
 import re
 
 from binascii import unhexlify
-from bunch import Bunch
+from munch import Munch as Bunch
 from struct import unpack
 
 # Import common utilites and base classes

--- a/cgsn_parsers/parsers/parse_vel3d.py
+++ b/cgsn_parsers/parsers/parse_vel3d.py
@@ -10,7 +10,7 @@ import os
 import re
 import scipy.io as sio
 
-from bunch import Bunch
+from munch import Munch as Bunch
 from calendar import timegm
 from datetime import datetime
 from pytz import timezone

--- a/cgsn_parsers/parsers/parse_velpt.py
+++ b/cgsn_parsers/parsers/parse_velpt.py
@@ -10,7 +10,7 @@ import os
 import re
 import scipy.io as sio
 
-from bunch import Bunch
+from munch import Munch as Bunch
 from calendar import timegm
 from datetime import datetime
 from pytz import timezone


### PR DESCRIPTION
`munch` is the successor to `bunch` and is backwards compatible.   I switch to `munch` and the workflows I tested still worked. 

But a question:  I did a global replace thusly:
```
$ cd /github/cgsn-parsers/cgsn_parsers/parsers
$ sed -i 's/from bunch import Bunch/from munch import Munch as Bunch/g' *.py
```
and five files got changed (as you can see in this PR).   

But should only `common.py` have changed?

And perhaps these lines in the other four files are not necessary?
https://github.com/rsignell-usgs/cgsn-parsers/blob/master/cgsn_parsers/parsers/parse_adcp.py#L21

If so, I can revise the PR